### PR TITLE
Error at line 30

### DIFF
--- a/gdprprivacysetup.php
+++ b/gdprprivacysetup.php
@@ -27,8 +27,8 @@ class GdprPrivacySetupPlugin extends Plugin
     private $cookieName;
     private $userConsent;
 
-    private const STYLE_BOTTOM_BAR = 0;
-    private const STYLE_MODAL = 1;
+    const STYLE_BOTTOM_BAR = 0;
+    const STYLE_MODAL = 1;
 
     public static function getSubscribedEvents()
     {


### PR DESCRIPTION
When trying to install the plugin on my Grav website, I got an error and my website was not longer working.
Click the link to see the error's screenshot: https://the-abuzzers.d.pr/bk05zt

This is the original line 30 and 31:

    private const STYLE_BOTTOM_BAR = 0;
    private const STYLE_MODAL = 1;

This is the modification I made to the file:

    const STYLE_BOTTOM_BAR = 0;
    const STYLE_MODAL = 1;

After that, the website was working again, and the plugin is installed.